### PR TITLE
Change the way sets and dicts are handled in the library

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -83,10 +83,6 @@ static void *tryParentize(const valkeyReadTask *task, PyObject *obj) {
                     PyDict_SetItem(parent, last_key, obj);
                 }
                 break;
-            case VALKEY_REPLY_SET:
-                assert(PyAnySet_CheckExact(parent));
-                PySet_Add(parent, obj);
-                break;
             default:
                 assert(PyList_CheckExact(parent));
                 PyList_SET_ITEM(parent, task->idx, obj);
@@ -162,9 +158,6 @@ static void *createArrayObject(const valkeyReadTask *task, size_t elements) {
     switch (task->type) {
         case VALKEY_REPLY_MAP:
             obj = PyDict_New();
-            break;
-        case VALKEY_REPLY_SET:
-            obj = PySet_New(NULL);
             break;
         default:
             obj = PyList_New(elements);

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -140,11 +140,23 @@ def test_set(reader):
 
 def test_set_with_nested_dict(reader):
   reader.feed(b"~2\r\n+tangerine\r\n%1\r\n+a\r\n:1\r\n")
-  assert [b"tangerine", {b"a": 1}] == reader.gets()
+  assert [b"tangerine", [(b"a", 1)]] == reader.gets()
+
+def test_dict_with_nested_set(reader):
+  reader.feed(b"%1\r\n+a\r\n~2\r\n:1\r\n:2\r\n")
+  assert [(b"a", [1, 2])] == reader.gets()
+
+def test_map_inside_list(reader):
+  reader.feed(b"*1\r\n%1\r\n+a\r\n:1\r\n")
+  assert [[(b"a", 1)]] == reader.gets()
+
+def test_map_inside_set(reader):
+  reader.feed(b"~1\r\n%1\r\n+a\r\n:1\r\n")
+  assert [[(b"a", 1)]] == reader.gets()
 
 def test_dict(reader):
   reader.feed(b"%2\r\n+radius\r\n,4.5\r\n+diameter\r\n:9\r\n")
-  assert {b"radius": 4.5, b"diameter": 9} == reader.gets()
+  assert [(b"radius", 4.5), (b"diameter", 9)] == reader.gets()
 
 def test_vector(reader):
   reader.feed(b">4\r\n+pubsub\r\n+message\r\n+channel\r\n+message\r\n")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -136,7 +136,11 @@ def test_none(reader):
 
 def test_set(reader):
   reader.feed(b"~3\r\n+tangerine\r\n_\r\n,10.5\r\n")
-  assert {b"tangerine", None, 10.5} == reader.gets()
+  assert [b"tangerine", None, 10.5] == reader.gets()
+
+def test_set_with_nested_dict(reader):
+  reader.feed(b"~2\r\n+tangerine\r\n%1\r\n+a\r\n:1\r\n")
+  assert [b"tangerine", {b"a": 1}] == reader.gets()
 
 def test_dict(reader):
   reader.feed(b"%2\r\n+radius\r\n,4.5\r\n+diameter\r\n:9\r\n")


### PR DESCRIPTION
This pull request backports yet unmerged [PR from hiredis](https://github.com/redis/hiredis-py/issues/188) and additionally changes the way dicts are handled.

This changes are necessary because RESP3 allows:
* dict value to be a set
* dict key to be a set or an array
* have a dict inside a set

None of these things are allowed in Python. Therefore it was decided to replace sets with lists and dicts with lists of tuples. The client is supposed to handle the types and convert if necessary themselves.

**This is a breaking change**