### PR TITLE
Introduce a new way of handling array objects

### DIFF
--- a/libvalkey/libvalkey.pyi
+++ b/libvalkey/libvalkey.pyi
@@ -21,6 +21,7 @@ class Reader:
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         notEnoughData: Any = ...,
+        listOnly: bool = ...,
     ) -> None: ...
 
     def feed(

--- a/src/reader.c
+++ b/src/reader.c
@@ -14,6 +14,7 @@ static PyObject *Reader_getmaxbuf(libvalkey_ReaderObject *self);
 static PyObject *Reader_len(libvalkey_ReaderObject *self);
 static PyObject *Reader_has_data(libvalkey_ReaderObject *self);
 static PyObject *Reader_set_encoding(libvalkey_ReaderObject *self, PyObject *args, PyObject *kwds);
+static PyObject *Reader_listOnly(PyObject *self, void *closure);
 
 static PyMethodDef libvalkey_ReaderMethods[] = {
     {"feed", (PyCFunction)Reader_feed, METH_VARARGS, NULL },
@@ -24,6 +25,11 @@ static PyMethodDef libvalkey_ReaderMethods[] = {
     {"has_data", (PyCFunction)Reader_has_data, METH_NOARGS, NULL },
     {"set_encoding", (PyCFunction)Reader_set_encoding, METH_VARARGS | METH_KEYWORDS, NULL },
     { NULL }  /* Sentinel */
+};
+
+static PyGetSetDef libvalkey_ReaderGetSet[] = {
+    {"listOnly", (getter)Reader_listOnly, NULL, NULL, NULL},
+    {NULL}  /* Sentinel */
 };
 
 PyTypeObject libvalkey_ReaderType = {
@@ -56,7 +62,7 @@ PyTypeObject libvalkey_ReaderType = {
     0,                            /*tp_iternext */
     libvalkey_ReaderMethods,        /*tp_methods */
     0,                            /*tp_members */
-    0,                            /*tp_getset */
+    libvalkey_ReaderGetSet,        /*tp_getset */
     0,                            /*tp_base */
     0,                            /*tp_dict */
     0,                            /*tp_descr_get */
@@ -529,4 +535,11 @@ static PyObject *Reader_set_encoding(libvalkey_ReaderObject *self, PyObject *arg
 
     Py_RETURN_NONE;
 
+}
+
+static PyObject *Reader_listOnly(PyObject *obj, void *closure) {
+    libvalkey_ReaderObject *self = (libvalkey_ReaderObject*)obj;
+    PyObject *result = PyBool_FromLong(self->listOnly);
+    Py_INCREF(result);
+    return result;
 }

--- a/src/reader.h
+++ b/src/reader.h
@@ -15,6 +15,8 @@ typedef struct {
     PyObject *notEnoughDataObject;
     int listOnly;
 
+    PyObject *pendingObject;
+
     /* Stores error object in between incomplete calls to #gets, in order to
      * only set the error once a full reply has been read. Otherwise, the
      * reader could get in an inconsistent state. */

--- a/src/reader.h
+++ b/src/reader.h
@@ -13,6 +13,7 @@ typedef struct {
     PyObject *protocolErrorClass;
     PyObject *replyErrorClass;
     PyObject *notEnoughDataObject;
+    int listOnly;
 
     /* Stores error object in between incomplete calls to #gets, in order to
      * only set the error once a full reply has been read. Otherwise, the

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -3,16 +3,7 @@ import pytest
 
 @pytest.fixture(params=[True, False])
 def reader(request):
-  class TestReader(libvalkey.Reader):
-    def __init__(self, *args, **kwargs):
-      super().__init__(*args, **kwargs)
-      self.__listOnly = kwargs["listOnly"]
-
-    @property
-    def listOnly(self):
-      return self.__listOnly
-
-  return TestReader(listOnly=request.param)
+  return libvalkey.Reader(listOnly=request.param)
 
 # def reply():
 #   return reader.gets()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -161,6 +161,41 @@ def test_dict(reader):
   )
   assert expected == reader.gets()
 
+def test_set_with_nested_dict(reader):
+  reader.feed(b"~2\r\n+tangerine\r\n%1\r\n+a\r\n:1\r\n")
+  if reader.listOnly:
+    assert [b"tangerine", [(b"a", 1)]] == reader.gets()
+  else:
+    with pytest.raises(TypeError):
+      reader.gets()
+
+def test_dict_with_nested_set(reader):
+  reader.feed(b"%1\r\n+a\r\n~2\r\n:1\r\n:2\r\n")
+  expected = (
+      [(b"a", [1, 2])]
+      if reader.listOnly
+      else {b"a": {1, 2}}
+  )
+  assert expected == reader.gets()
+
+def test_map_inside_list(reader):
+  reader.feed(b"*1\r\n%1\r\n+a\r\n:1\r\n")
+  expected = (
+      [[(b"a", 1)]]
+      if reader.listOnly
+      else [{b"a": 1}]
+  )
+  assert expected == reader.gets()
+
+def test_map_inside_set(reader):
+  reader.feed(b"~1\r\n%1\r\n+a\r\n:1\r\n")
+  if reader.listOnly:
+    assert [[(b"a", 1)]] == reader.gets()
+  else:
+    # Map inside set is not allowed in Python
+    with pytest.raises(TypeError):
+      reader.gets()
+
 def test_vector(reader):
   reader.feed(b">4\r\n+pubsub\r\n+message\r\n+channel\r\n+message\r\n")
   assert [b"pubsub", b"message", b"channel", b"message"] == reader.gets()


### PR DESCRIPTION
This PR supercedes #2. 

After that pull request, the following changes were done:
1. Results of `PyDict_SetItem` and `PySet_Add` are now checked to prevent crashing in case of incorrect Python objects
2. The new behaviour is now enabled explicitly by the new kwarg `listOnly` in `Reader` constructor. By default the old behaviour is used
3. Tests were changed to test both old and new behaviours

Any comments and suggestions are welcome!