### PR TITLE
reader: partly restore the previous behaviour

### DIFF
--- a/libvalkey/libvalkey.pyi
+++ b/libvalkey/libvalkey.pyi
@@ -21,7 +21,7 @@ class Reader:
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
         notEnoughData: Any = ...,
-        listOnly: bool = ...,
+        convertSetsToLists: bool = ...,
     ) -> None: ...
 
     def feed(

--- a/src/reader.h
+++ b/src/reader.h
@@ -13,7 +13,7 @@ typedef struct {
     PyObject *protocolErrorClass;
     PyObject *replyErrorClass;
     PyObject *notEnoughDataObject;
-    int listOnly;
+    int convertSetsToLists;
 
     PyObject *pendingObject;
 


### PR DESCRIPTION
Version 3.0.0 changed the way sets and maps are handled in libvalkey-py. Now, all the sets and dicts were treated as lists, maps being lists of tuples. This change was done without keeping `valkey-py` in mind. As it turned out, this way of handling maps is not really applicable to `valkey-py` because `valkey-py` doesn't know what data type it expects. Hence, it can't tell whether the returned list should be treated as a map or left as it is.

This commit partly reverts the behaviour to what it was pre-3.0.0, leaving maps as dicts all the time. All sets, though, are being treated as lists now when `convertSetsToLists=True`. While this behaviour excludes some exotic use cases allowed by RESP like set or array being a key of a map, it does not affect the consumer library as much, and none of such exotic use cases are being used in the real world anyway.