### PR TITLE
MANIFEST: add exported headers directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include MANIFEST.in
 include README.md
 include src/*.[ch]
 include vendor/libvalkey/COPYING
+include vendor/libvalkey/include/valkey/*.h
 include vendor/libvalkey/src/*.[ch]
 graft tests
 global-exclude __pycache__


### PR DESCRIPTION
When hiredis was forked to libvalkey, it changed its layout to have a proper `src` and `include` directories. Upon forking hiredis-py to libvalkey-py, `include` directory was missing from the source package which means the module could not be built from the sdist package. This issue was hidden by the fact that all the supported systems were provided with a binary package hence noone actually needed to build it.

This was revealed when people started using libvalkey-py with Python 3.13 that was missing a binary package.

This commit fixes this bug by adding `include` directory to MANIFEST.in

Fixes #19