### PR TITLE
Fix reply map value memory leak

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -87,13 +87,13 @@ static void *tryParentize(const valkeyReadTask *task, PyObject *obj) {
                         Py_DECREF(obj);
                         return NULL;
                     }
-                    if (PyDict_SetItem(parent, self->pendingObject, obj) < 0) {
-                        Py_DECREF(obj);
-                        Py_DECREF(self->pendingObject);
-                        self->pendingObject = NULL;
+                    int x = PyDict_SetItem(parent, self->pendingObject, obj);
+                    Py_DECREF(obj);
+                    Py_DECREF(self->pendingObject);
+                    self->pendingObject = NULL;
+                    if (x < 0) {
                         return NULL;
                     }
-                    self->pendingObject = NULL;
                 }
                 break;
             case VALKEY_REPLY_SET:


### PR DESCRIPTION
https://github.com/redis/hiredis-py/issues/175

not sure why PyDict_SetItem is returning -1 even though the assignment seems to be successful. But it was skipping over the Py_DECREF calls causing a memory leak.