### PR TITLE
Test Python thread safety with pytest-run-parallel

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -45,7 +45,7 @@ jobs:
           pip install -U pip setuptools wheel
           pip install -r dev_requirements.txt
           python setup.py build_ext --inplace
-          python -m pytest
+          python -m pytest --iterations=8 --parallel-threads=auto
       - name: build and install the wheel
         run: |
           python setup.py bdist_wheel

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,7 @@ black==24.3.0
 flake8==4.0.1
 isort==5.10.1
 pytest>=7.0.0
+pytest-run-parallel>=0.7.1
 setuptools
 vulture>=2.3.0
 wheel>=0.30.0

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -1,8 +1,12 @@
 import gc
 
+import pytest
+
 import libvalkey
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_reader_gc():
     class A:
         def __init__(self):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -174,6 +174,8 @@ def test_dict(reader):
     assert {b"radius": 4.5, b"diameter": 9} == reader.gets()
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_set_with_nested_dict(reader):
     reader.feed(b"~2\r\n+tangerine\r\n%1\r\n+a\r\n:1\r\n")
     if reader.convertSetsToLists:
@@ -196,6 +198,8 @@ def test_map_inside_list(reader):
     assert [{b"a": 1}] == reader.gets()
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_map_inside_set(reader):
     reader.feed(b"~1\r\n%1\r\n+a\r\n:1\r\n")
     if reader.convertSetsToLists:
@@ -206,6 +210,8 @@ def test_map_inside_set(reader):
             reader.gets()
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_set_as_map_key(reader):
     reader.feed(b"%1\r\n~1\r\n:1\r\n:2\r\n")
     with pytest.raises(TypeError):
@@ -388,6 +394,8 @@ def test_feed_bytearray(reader):
     assert b"ok" == reader.gets()
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_maxbuf(reader):
     defaultmaxbuf = reader.getmaxbuf()
     reader.setmaxbuf(0)
@@ -400,6 +408,8 @@ def test_maxbuf(reader):
         reader.setmaxbuf(-4)
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_len(reader):
     assert reader.len() == 0
     data = b"+ok\r\n"
@@ -416,6 +426,8 @@ def test_len(reader):
     assert reader.len() == 5
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.thread_unsafe
 def test_reader_has_data(reader):
     assert reader.has_data() is False
     data = b"+ok\r\n"


### PR DESCRIPTION
https://py-free-threading.github.io
https://pypi.org/project/pytest-run-parallel

% `uvx --with="valkey[libvalkey]" python3.14t -c "import valkey"`
```
Installed 2 packages in 5ms
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to
    load module 'libvalkey.libvalkey', which has not declared that it can run safely without the GIL.
    To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
```