### PR TITLE
pip install --upgrade

### DIFF
--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -40,7 +40,7 @@ jobs:
           run: |
             curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python3.9 get-pip.py
-            /usr/local/bin/pip install -U pip setuptools wheel
+            /usr/local/bin/pip install --upgrade pip setuptools wheel
             /usr/local/bin/pip install -r dev_requirements.txt
             /usr/local/bin/python3.9 setup.py build_ext --inplace
             python3.9 -m pytest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -42,7 +42,7 @@ jobs:
           cache-dependency-path: dev_requirements.txt
       - name: run tests
         run: |
-          pip install -U pip setuptools wheel
+          pip install --upgrade pip setuptools wheel
           pip install -r dev_requirements.txt
           python setup.py build_ext --inplace
           python -m pytest


### PR DESCRIPTION
`pip install -U` can be quite opaque to readers because pip install currently has six `--u*` options, including `--user`.

`pip install --upgrade` makes the intention clearer in code that others will read.

% `python3 -m pip install --help | grep "\-\-u"`
```
  --user                      Install to the Python user install directory for
  -U, --upgrade               Upgrade all specified packages to the newest
  --upgrade-strategy <upgrade_strategy>
  --use-pep517                Use PEP 517 for building source distributions
  --use-feature <feature>     Enable new functionality, that may be backward
  --use-deprecated <feature>  Enable deprecated functionality, that will be
``` 