### PR TITLE
Drop support for CPython 3.8 and PyPy3.8

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       max-parallel: 15
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
       fail-fast: false
     env:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python -m pytest
 
 ### Requirements
 
-libvalkey-py requires **Python 3.8+**.
+libvalkey-py requires **Python 3.9+**.
 
 Make sure Python development headers are available when installing libvalkey-py.
 On Ubuntu/Debian systems, install them with `apt-get install python3-dev`.

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     packages=["libvalkey"],
     package_data={"libvalkey": ["libvalkey.pyi", "py.typed"]},
     ext_modules=[ext],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     project_urls={
         "Changes": "https://github.com/valkey-io/libvalkey-py/releases",
         "Issue tracker": "https://github.com/valkey-io/libvalkey-py/issues",
@@ -102,7 +102,6 @@ setup(
         "Programming Language :: C",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 3.8 went end-of-life more than a year ago, and modern tools like [`pytest-run-parallel`](https://pypi.org/project/pytest-run-parallel) do not support it.
* https://devguide.python.org/versions
* https://pypy.org/download.html
* #42