### PR TITLE
github: update runners

### DIFF
--- a/.github/workflows/block-autosquash-commits.yaml
+++ b/.github/workflows/block-autosquash-commits.yaml
@@ -6,7 +6,7 @@ jobs:
   message-check:
     name: Block Autosquash Commits
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Block Autosquash Commits

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,6 +4,6 @@ on: [pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: tisonkun/actions-dco@v1.1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -26,7 +26,7 @@ jobs:
       max-parallel: 15
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-slim', 'windows-latest', 'macos-latest']
       fail-fast: false
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -10,7 +10,7 @@ jobs:
 
   build_sdist:
     name: Build source dist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/setup-python@v6
         with:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-latest]
+        os: [ubuntu-slim, windows-latest, macos-latest]
     env:
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       MACOSX_DEPLOYMENT_TARGET: "11.0"
@@ -61,7 +61,7 @@ jobs:
   publish:
     name: PyPI publish
     needs: ['build_sdist', 'build_wheels']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     environment: pypi
     permissions:
       id-token: write

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -68,11 +68,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: ubuntu-20.04-wheels
+          name: ubuntu-slim-wheels
           path: artifacts/linux
       - uses: actions/download-artifact@v8
         with:
-          name: windows-2019-wheels
+          name: windows-latest-wheels
           path: artifacts/windows
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/rebase-merge.yml
+++ b/.github/workflows/rebase-merge.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   forbid-merge-commits:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Run Forbid Merge Commits Action
         uses: motlin/forbid-merge-commits-action@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write #  to add label to PR (release-drafter/release-drafter)
       contents: write #  to create a github release (release-drafter/release-drafter)
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v7

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   check-spelling:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   check-spelling:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Use ubuntu-slim where large machine is not needed. Otherwise, use *-latest image so that it doesn't get expired